### PR TITLE
Add script singularity_test.sh

### DIFF
--- a/singularity_test.sh
+++ b/singularity_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+timeout_length=60s
+
+help="Usage: $0 [options] <file/dir names to check exist>
+
+Checks directories are visible from inside singularity container.  Uses
+'timeout' command to give up after set period of time.
+
+Options:
+  -h    Show this help and exit
+  -t    String passed to timeout command [$timeout_length]
+  -x    Be more verbose by setting the bash -x option
+
+Example - look for 'foo' and 'bar'. Give up after 42 seconds:
+  $0 -t 42s foo bar
+"
+
+
+OPTIND=1
+
+while getopts "ht:x" opt; do
+    case "$opt" in
+    h)  echo "$help"
+        exit 0
+        ;;
+    t)  timeout_length=$OPTARG
+        ;;
+    x)  set -x
+        ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+[ "${1:-}" = "--" ] && shift
+
+if [ $# -lt 1 ]; then
+    >&2 echo "Error: must provide at least one file/directory name to look for"
+    exit 1
+fi
+
+# See https://stackoverflow.com/questions/59895/how-to-get-the-source-directory-of-a-bash-script-from-within-the-script-itself
+this_script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+simg=$this_script_dir/alpine.simg
+timeout $timeout_length singularity exec $simg ls $@


### PR DESCRIPTION
Adds script `singularity_test.sh` which tries for a default of 60s to `ls` directories provided as input to the script.

Note: it assumes that the script and the singularity container that it runs are in the same directory. Open to suggestions for this because strictly speaking using `$0` to get the script's directory is [not recommended](http://mywiki.wooledge.org/BashFAQ/028) (but in reality everyone does it). But this will work fine on our clusters.